### PR TITLE
Implement multi-arg set/unset and version independent tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # grubenv
-Simple Grub Environemnt Block Edit Tool
+Simple Grub Environment Block Edit Tool with support for the same commands as
+`grub-editenv`.  The `set` and `unset` commands accept multiple arguments just
+like `grub-editenv`.


### PR DESCRIPTION
## Summary
- support multiple arguments for `set` and `unset`
- tolerate missing warning header when reading env files
- rewrite tests to compare env contents rather than raw files
- document multi-argument support in README

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686781320e68832099dcd752e8b945e4