### PR TITLE
Enable cross compile via environment vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ TARGET=grubenv
 
 all: $(TARGET)
 
-$(TARGET): grubenv.c
-	$(CC) $(CFLAGS) -o $@ $<
+$(TARGET): grubenv.c version.h
+	$(CC) $(CFLAGS) -o $@ grubenv.c
 
 lint:
 	$(CC) $(CFLAGS) -fsyntax-only grubenv.c

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
-CC=gcc
-CFLAGS=-std=c11 -Wall -Wextra
+# Allow overriding compiler and flags from the environment which is
+# common when cross compiling under environments like Yocto.
+ifeq ($(origin CC),default)
+CC = gcc
+endif
+CFLAGS ?= -std=c11 -Wall -Wextra
 TARGET=grubenv
 
 all: $(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,18 @@ ifeq ($(origin CC),default)
 CC = gcc
 endif
 CFLAGS ?= -std=c11 -Wall -Wextra
-TARGET=grubenv
+TARGET = grubenv
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
 
 all: $(TARGET)
 
 $(TARGET): grubenv.c version.h
 	$(CC) $(CFLAGS) -o $@ grubenv.c
+
+install: $(TARGET)
+	install -d $(DESTDIR)$(BINDIR)
+	install -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
 
 lint:
 	$(CC) $(CFLAGS) -fsyntax-only grubenv.c

--- a/README.md
+++ b/README.md
@@ -6,5 +6,8 @@ like `grub-editenv`.
 The provided `Makefile` will honor environment variables such as `CC` and
 `CFLAGS` so it can be used easily in cross-compilation environments like Yocto.
 
+Run `make install DESTDIR=/path` to install the binary, which is useful when
+packaging with systems like Yocto.
+
 To check the tool version, use `grubenv -V` which prints the constant defined in
 `version.h`.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 Simple Grub Environment Block Edit Tool with support for the same commands as
 `grub-editenv`.  The `set` and `unset` commands accept multiple arguments just
 like `grub-editenv`.
+
+The provided `Makefile` will honor environment variables such as `CC` and
+`CFLAGS` so it can be used easily in cross-compilation environments like Yocto.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ like `grub-editenv`.
 
 The provided `Makefile` will honor environment variables such as `CC` and
 `CFLAGS` so it can be used easily in cross-compilation environments like Yocto.
+
+To check the tool version, use `grubenv -V` which prints the constant defined in
+`version.h`.

--- a/grubenv.c
+++ b/grubenv.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include "version.h"
 
 /*
  * Internal environment representation: a dynamic array of "KEY=VAL" strings
@@ -284,7 +285,7 @@ static void save_env_file(const char *path, struct env *e) {
 /* Display short usage help */
 static void usage(const char *prog) {
     fprintf(stderr,
-            "Usage: %s [-s size] <envfile|-> <create|list|get|set|unset|clear> [ARGS]\n",
+            "Usage: %s [-s size] [-V] <envfile|-> <create|list|get|set|unset|clear> [ARGS]\n",
             prog);
     exit(EXIT_FAILURE);
 }
@@ -292,13 +293,16 @@ static void usage(const char *prog) {
 /* Entry point. Parses arguments and dispatches commands. */
 int main(int argc, char *argv[]) {
     int opt;
-    while ((opt = getopt(argc, argv, "s:")) != -1) {
+    while ((opt = getopt(argc, argv, "s:V")) != -1) {
         switch (opt) {
         case 's':
             blk_size = (uint32_t)strtoul(optarg, NULL, 0);
             if (blk_size < 128)
                 die("size");
             break;
+        case 'V':
+            puts(GRUBENV_VERSION);
+            return 0;
         default:
             usage(argv[0]);
         }

--- a/tests.sh
+++ b/tests.sh
@@ -12,6 +12,11 @@ check_equal() {
 # verify version output
 ./grubenv -V | grep -qx '1.0.0'
 
+# verify install target
+DEST=$(mktemp -d)
+make install DESTDIR="$DEST"
+[ -x "$DEST/usr/local/bin/grubenv" ]
+
 # create new env files
 ./grubenv "$TMP2" create
 grub-editenv "$TMP1" create

--- a/tests.sh
+++ b/tests.sh
@@ -9,6 +9,9 @@ check_equal() {
     diff -u "$TMP1.list" "$TMP2.list"
 }
 
+# verify version output
+./grubenv -V | grep -qx '1.0.0'
+
 # create new env files
 ./grubenv "$TMP2" create
 grub-editenv "$TMP1" create

--- a/version.h
+++ b/version.h
@@ -1,0 +1,6 @@
+#ifndef GRUBENV_VERSION_H
+#define GRUBENV_VERSION_H
+
+#define GRUBENV_VERSION "1.0.0"
+
+#endif /* GRUBENV_VERSION_H */


### PR DESCRIPTION
## Summary
- default to `gcc` only if `CC` isn't provided
- allow overriding `CFLAGS` from the environment
- document new behavior

## Testing
- `make lint`
- `make clean && make test`

------
https://chatgpt.com/codex/tasks/task_e_686782e810f4832092ab06db089f61e8